### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,18 @@
 - The clip-path curve generator closes the `shape()` using `vline` then `hline` (based on the chosen start corner coords).
 - `ToggleGrid` preserves intended toggle styling by extending `ToggleGroup` context with `grid?: boolean`.
 - The generator's "Show annotations" toggle controls only gridlines + axis label overlay, while the curve/handles/start marker remain visible.
+
+## Cursor Cloud specific instructions
+
+This is a static Next.js 16 site (App Router) with no database, no API routes, and no required environment variables.
+
+**Commands** — see `README.md` and `package.json` scripts for the canonical list:
+- Dev server: `npm run dev` (port 3000)
+- Lint: `npm run lint` (ESLint; pre-existing warnings/errors exist — unused vars and unescaped entities)
+- Build: `npm run build` (static export to `out/`)
+- Format: `npm run format` / `npm run format:check` (Prettier)
+
+**Gotchas:**
+- The dev server connects to an optional "agentation" overlay on port 4747 — this is not required and can be ignored.
+- `@vercel/analytics` and `@vercel/speed-insights` are no-ops locally; they only activate on Vercel deployments.
+- The homepage doubles as the About page (no separate `/about` route in the nav — it renders at `/`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment guidance for future Cloud Agents.

### What's included
- Canonical dev commands (dev server, lint, build, format) with reference to `README.md`
- Non-obvious gotchas: agentation overlay on port 4747, Vercel analytics no-ops locally, homepage doubling as About page

### Demo

<a href="https://cursor.com/agents/bc-a722da1f-a51c-4b91-b898-8e9e3a3a2a6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbob-fyi-site-demo.mp4"><img src="https://cursor.com/artifacts/c/art-b73ad01f-89d5-4240-94e5-a02f9e8d4891" alt="bob-fyi-site-demo.mp4" /></a>

Site running on `localhost:3000` with all pages rendering correctly.

![Homepage](https://cursor.com/artifacts/c/art-0b264582-dae7-4350-a593-7b5b6db6d73c)
![Components page](https://cursor.com/artifacts/c/art-ba3fd4ae-6678-4f2f-bc88-5dbb4a6f8ef2)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a722da1f-a51c-4b91-b898-8e9e3a3a2a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a722da1f-a51c-4b91-b898-8e9e3a3a2a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

