### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/app/api/letterboxd/route.ts
+++ b/app/api/letterboxd/route.ts
@@ -18,11 +18,11 @@ function getPosterUrl(description = "") {
 
 function decodeText(text = "") {
   return text
-    .replaceAll("&amp;", "&")
     .replaceAll("&quot;", '"')
     .replaceAll("&#39;", "'")
     .replaceAll("&ndash;", "–")
-    .replaceAll("&mdash;", "—");
+    .replaceAll("&mdash;", "—")
+    .replaceAll("&amp;", "&");
 }
 
 function getListFilms(description = "") {


### PR DESCRIPTION
Potential fix for [https://github.com/robertweisbecker/robertweisbecker.github.io/security/code-scanning/1](https://github.com/robertweisbecker/robertweisbecker.github.io/security/code-scanning/1)

To fix this, keep the same functionality but change unescape order in `decodeText` so `&amp;` is decoded last.  
General rule: when **escaping**, escape `&` first; when **unescaping**, unescape `&` last.

In `app/api/letterboxd/route.ts`, edit only `decodeText` (lines 19–26 region): move `.replaceAll("&amp;", "&")` to the end of the chain. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
